### PR TITLE
Prevent additional Script Error from transmitting.

### DIFF
--- a/util/logger.js
+++ b/util/logger.js
@@ -3,8 +3,10 @@ let jsonURL = 'https://api.myjson.com/bins'
 let token = window._trackJs.token
 let trackJsCaptureUrl = `https://capture.trackjs.com/capture?token=${token}`
 let actions = []
+let supressNextScriptError = false
 
 function trackError (payload) {
+  supressNextScriptError = true
   // save actions to a json file (myjson.com)
   axios.post(jsonURL, actions)
     .then(function (response) {
@@ -31,6 +33,10 @@ export function configureTracker () {
 
   window.trackJs.configure({
     onError: (payload, error) => {
+      if(payload.message.indexOf('Script error') >= 0 && supressNextScriptError){
+        supressNextScriptError = false
+        return false
+      }
       trackError(payload)
       return false // We will send the payload ourselves
     }


### PR DESCRIPTION
After catching and tracking an error, TrackJS rethrows the error to let
the calling code deal with it.  However, this will cause our
window.onerror handler to double track the additional message.  This
supresses that.
